### PR TITLE
#16 increase memory for production build in pipeline

### DIFF
--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -33,6 +33,7 @@ jobs:
         run: npm run build
         env:
           CI: false
+          NODE_OPTIONS: "--max_old_space_size=6144"
       - name: Upload Client
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -47,6 +47,7 @@ jobs:
         run: npm run build
         env:
           CI: false
+          NODE_OPTIONS: "--max_old_space_size=6144"
       - name: Upload Server
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Increases javascript heap for build pipelin (production) to 6GB.
Further optimizations may be possible with the node scripts themselves, but this change at least provides an upper ceiling appropriate for the github actions environment (7GB ram)