### PR TITLE
#1 Add initial Dockerfile & extend CI

### DIFF
--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -50,12 +50,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: github.event.pull_request.merged == 'true'
+        if: ${{ github.event.pull_request.merged == 'true' }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: (github.event.pull_request.merged == 'true')
+          push:  ${{ github.event.pull_request.merged == 'true' }}
           tags: planetf1/egeria-presentation-server:latest
           context: .
           file: ./Dockerfile

--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -43,11 +43,6 @@ jobs:
         env:
           CI: false
           NODE_OPTIONS: "--max_old_space_size=6144"
-      - name: Upload 
-        uses: actions/upload-artifact@v2
-        with:
-          name: build
-          path: .
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub

--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -34,11 +34,6 @@ jobs:
         env:
           CI: false
           NODE_OPTIONS: "--max_old_space_size=6144"
-      - name: Upload Client
-        uses: actions/upload-artifact@v2
-        with:
-          name: client
-          path: cra-client/build
       - name: Install dependencies for server
         working-directory: ./cra-server
         run: npm install
@@ -48,11 +43,11 @@ jobs:
         env:
           CI: false
           NODE_OPTIONS: "--max_old_space_size=6144"
-      - name: Upload Server
+      - name: Upload 
         uses: actions/upload-artifact@v2
         with:
-          name: server
-          path: cra-client/server
+          name: build
+          path: .
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
@@ -67,6 +62,8 @@ jobs:
         with:
           push: (github.event.pull_request.merged == 'true')
           tags: odpi/egeria-presentation-server:latest
+          context: .
+          file: ./Dockerfile
           #build-args: |
           #  arg1=value1
           #  arg2=value2

--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -56,7 +56,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: (github.event.pull_request.merged == 'true')
-          tags: odpi/egeria-presentation-server:latest
+          tags: planetf1/egeria-presentation-server:latest
           context: .
           file: ./Dockerfile
           #build-args: |

--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -53,3 +53,22 @@ jobs:
         with:
           name: server
           path: cra-client/server
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: github.event.pull_request.merged == 'true'
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: (github.event.pull_request.merged == 'true')
+          tags: odpi/egeria-presentation-server:latest
+          #build-args: |
+          #  arg1=value1
+          #  arg2=value2
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project
+
+# This Dockerfile should be run from the parent directory of the egeria-reac-ui directory
+# ie
+# docker -f ./Dockerfile 
+
+# The npm build for the UI must have fully completed prior to this
+
+FROM node:14-alpine
+
+# Thes are optional tags used to add additional metadata into the docker image
+# These may be supplied by the pipeline in future - until then they will default
+
+ARG version=2.6-SNAPSHOT
+ARG VCS_REF=unknown
+ARG VCS_ORIGIN=unknown
+ARG BUILD_TIME=unknown
+ARG VCS_DATE=unknown
+
+ENV version ${version}
+
+# Labels from https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys (with additions prefixed    ext)
+LABEL org.opencontainers.image.vendor = "ODPi" \
+      org.opencontainers.image.title = "Egeria" \
+      org.opencontainers.image.description = "Egeria Presentation Server" \
+      org.opencontainers.image.url = "https://egeria.odpi.org/" \
+      org.opencontainers.image.source = "$VCS_ORIGIN" \
+      org.opencontainers.image.authors = "ODPi Egeria" \
+      org.opencontainers.image.revision = "$VCS_REF" \
+      org.opencontainers.image.licenses = "Apache-2.0" \
+      org.opencontainers.image.created = "$BUILD_TIME" \
+      org.opencontainers.image.version = "$version" \
+      org.opencontainers.image.documentation = "https://github.com/odpi/egeria-react-ui" \
+      org.opencontainers.image.ext.vcs-date = "$VCS_DATE" \
+      org.opencontainers.image.ext.docker.cmd = "docker run -d -p 8091:8091 odpi/egeria-presentation-server" \
+      org.opencontainers.image.ext.docker.debug = "docker exec -it $CONTAINER /bin/sh" \
+
+
+RUN mkdir -p /home/node/egeria-react-ui
+WORKDIR /home/node/egeria-react-ui
+
+# Note we copy the entire tree -- once the dev team have clarified what is needed, this can be optimized
+# We also do not yet do a multi stage build, as this requires clarity over what needs to be present in the runtime
+# vs the development environment. In addition we may wish to use nginx or similar for a production case.
+
+COPY --chown=node:node .  .
+
+
+USER 1000
+EXPOSE 8091
+
+WORKDIR cra-server
+
+CMD [ "npm", "run", "prod" ]


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

- Adds simple Dockerfile (copies full build, runs 'npm run prod') - see content for further info
- Extends current CI build step to build docker image even for PR, and for a merge build only, also pushes as :latest

Caveats
 - Currently pushes image to my repo (planetf1) -- once working will contact ODPI admins to use the proper odpi repository instead
  - future step could publish PR images ie to the github container registry, but this is not currently done. 
  - need to figure out versioning