### PR TITLE
#46 correct inverted condition for docker login

### DIFF
--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -50,12 +50,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-        if: ${{ github.event_name == 'push' && github.repository != 'odpi/egeria-react-ui' }}
+        if: ${{ github.event_name == 'push' && github.repository == 'odpi/egeria-react-ui' }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push:  ${{ github.event_name == 'push' && github.repository != 'odpi/egeria-react-ui' }} 
+          push:  ${{ github.event_name == 'push' && github.repository == 'odpi/egeria-react-ui' }} 
           tags: odpi/egeria-presentation-server:latest
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Corrects #46 (again)
Prior change had condition inverted - seen when verifying the merge publish
Interestingly I *did not* get any attempt to build on my fork, which suggests the original condition was sufficient. 
@grahamwallis will merge this one too.. then see if any of your later changes cause problems