### PR TITLE
odpi/egeria#5686 fully qualify base image name in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 
 # The npm build for the UI must have fully completed prior to this
 
-FROM node:14-alpine
+FROM docker.io/library/node:14-alpine
 
 # Thes are optional tags used to add additional metadata into the docker image
 # These may be supplied by the pipeline in future - until then they will default


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Fully qualify all docker base image names as per https://github.com/odpi/egeria/issues/5670