### PR TITLE
#6 remove workaround of setting CI=false

### DIFF
--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -30,7 +30,6 @@ jobs:
         working-directory: ./cra-client
         run: npm run build
         env:
-          CI: false
           NODE_OPTIONS: "--max_old_space_size=6144"
       - name: Install dependencies for server
         working-directory: ./cra-server
@@ -39,7 +38,6 @@ jobs:
         working-directory: ./cra-server
         run: npm run build
         env:
-          CI: false
           NODE_OPTIONS: "--max_old_space_size=6144"
       - name: get-npm-version
         id: package-version


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Fixes #6 

Removes workaround added in early stages of code development to allow code with warnings to build