### PR TITLE
Added NodeTypeName property to REST payload

### DIFF
--- a/cra-client/src/components/GlossaryAuthor/components/create/CreateRelationshipWizard.js
+++ b/cra-client/src/components/GlossaryAuthor/components/create/CreateRelationshipWizard.js
@@ -276,10 +276,12 @@ export default function CreateRelationshipWizard(props) {
       let end1 = {};
       end1.class = "RelationshipEnd";
       end1.nodeType = "Term";
+      end1.nodeTypeName = "Term";
       end1.nodeGuid = end1Node.systemAttributes.guid;
       let end2 = {};
       end2.class = "RelationshipEnd";
       end2.nodeType = "Term";
+      end2.nodeTypeName = "Term";
       end2.nodeGuid = end2Node.systemAttributes.guid;
       myRelationshipToCreate.end1 = end1;
       myRelationshipToCreate.end2 = end2;


### PR DESCRIPTION
Fixes issue #326

Signed-off-by: Sachin Naik <91499691+odttlnt@users.noreply.github.com>

The code has been changed to add code that will send the NodeTypeName in the body of the REST payload that is sent to create the relationship.
This fix is in conjunction with the fix for [issue6358 ](https://github.com/odpi/egeria/issues/6358) in Egeria core. Both when moved will resolve this issue.